### PR TITLE
Update 3 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders.nuspec
+++ b/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders.nuspec
@@ -17,9 +17,9 @@
     <description>ESP32 DeepSleep data provider for MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf deepsleep mako-iot ESP32</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.0.35" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.38.18612" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.14.20" />
+      <dependency id="nanoFramework.DependencyInjection" version="1.1.1" />
       <dependency id="nanoFramework.Hardware.Esp32" version="1.6.8" />
       <dependency id="nanoFramework.Logging" version="1.1.63" />
       <dependency id="nanoFramework.Runtime.Events" version="1.11.6" />

--- a/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders.nfproj
+++ b/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders.nfproj
@@ -25,14 +25,15 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.36.21434\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.38.18612\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="mscorlib">
-      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.14.20.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.14.20\lib\mscorlib.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nanoFramework.DependencyInjection, Version=1.0.35.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.0.35\lib\nanoFramework.DependencyInjection.dll</HintPath>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.1\lib\nanoFramework.DependencyInjection.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Hardware.Esp32">

--- a/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/packages.config
+++ b/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/packages.config
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.36.21434" targetFramework="netnano1.0" />
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnano1.0" />
-  <package id="nanoFramework.DependencyInjection" version="1.0.35" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.38.18612" targetFramework="netnano1.0" />
+  <package id="nanoFramework.CoreLibrary" version="1.14.20" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.1" targetFramework="netnano1.0" />
   <package id="nanoFramework.Hardware.Esp32" version="1.6.8" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.63" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.6" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.36.21434 to 1.0.38.18612</br>Bumps nanoFramework.CoreLibrary from 1.14.2 to 1.14.20</br>Bumps nanoFramework.DependencyInjection from 1.0.35 to 1.1.1</br>
[version update]

### :warning: This is an automated update. :warning:
