### PR TITLE
Refactor deep sleep handling in IoT device code

### DIFF
--- a/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/DeepSleepDataProviderConfiguration.cs
+++ b/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/DeepSleepDataProviderConfiguration.cs
@@ -4,6 +4,7 @@ namespace MakoIoT.Device.Services.ESP32.DeepSleepDataProviders
 {
     public sealed class DeepSleepDataProviderConfiguration
     {
-        public short DisableDeepSleepGpioPin { get; set; }
+        internal const short WakeUpDisabled = -1;
+        public short WakeUpGpioPin { get; set; }
     }
 }

--- a/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/Extensions/DeviceBuilderExtension.cs
+++ b/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/Extensions/DeviceBuilderExtension.cs
@@ -6,10 +6,10 @@ namespace MakoIoT.Device.Services.ESP32.DeepSleepDataProviders.Extensions
 
     public static class DeviceBuilderExtension
     {
-        public static IDeviceBuilder AddDeepSleepDataProviders(this IDeviceBuilder builder, short deepSleepDisableGpioPinNumber = -1)
+        public static IDeviceBuilder AddDeepSleepDataProviders(this IDeviceBuilder builder, short deepSleepDisableGpioPinNumber = DeepSleepDataProviderConfiguration.WakeUpDisabled)
         {
             builder.DeviceStarting += Builder_DeviceStarting;
-            builder.Services.AddSingleton(typeof(DeepSleepDataProviderConfiguration), new DeepSleepDataProviderConfiguration() { DisableDeepSleepGpioPin = deepSleepDisableGpioPinNumber });
+            builder.Services.AddSingleton(typeof(DeepSleepDataProviderConfiguration), new DeepSleepDataProviderConfiguration() { WakeUpGpioPin = deepSleepDisableGpioPinNumber });
             return builder;
         }
 


### PR DESCRIPTION
The deep sleep disable mechanism in our IoT device services is replaced with a wakeup mechanism. The GPIO pin connected to waking up the device from deep sleep is now configured through the DeepSleepDataProviderConfiguration. Use of this pin is adjusted throughout the codebase, also simplifying some constructors and error handling. Lastly, the logic is adjusted for determining if the device should go into deep sleep based on pin state.