### PR TITLE
Update GPIO pin opening method in DataPublisher

### DIFF
--- a/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/DataPublisher.cs
+++ b/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/DataPublisher.cs
@@ -25,7 +25,7 @@ namespace MakoIoT.Device.Services.ESP32.DeepSleepDataProviders
             if (configuration.WakeUpGpioPin != DeepSleepDataProviderConfiguration.WakeUpDisabled)
             {
                 _wakeupGpioPin = MapPinNumberToWakeUpEnum(configuration.WakeUpGpioPin);
-                _wakeupGpio = gpioController.OpenPin(configuration.WakeUpGpioPin);
+                _wakeupGpio = gpioController.OpenPin(configuration.WakeUpGpioPin, PinMode.InputPullDown);
             }
         }
 


### PR DESCRIPTION
The pin opening method in the DataPublisher class has been updated. The gpioController.OpenPin now also passes PinMode.InputPullDown, adjusting the pin mode during the opening process for more precise control.