### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders.nuspec
+++ b/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders.nuspec
@@ -17,7 +17,7 @@
     <description>ESP32 DeepSleep data provider for MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf deepsleep mako-iot ESP32</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" />
       <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.3" />
       <dependency id="nanoFramework.Hardware.Esp32" version="1.6.19" />

--- a/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders.nfproj
+++ b/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders.nfproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.46.2905\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.47.44904\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>

--- a/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/packages.config
+++ b/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.46.2905" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.47.44904" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.3" targetFramework="netnano1.0" />
   <package id="nanoFramework.Hardware.Esp32" version="1.6.19" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.46.2905 to 1.0.47.44904</br>
[version update]

### :warning: This is an automated update. :warning:
