### PR TITLE
Update 1 NuGet dependencies

### DIFF
--- a/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders.nuspec
+++ b/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders.nuspec
@@ -17,7 +17,7 @@
     <description>ESP32 DeepSleep data provider for MAKO-IoT</description>
     <tags>nanoFramework C# csharp netmf netnf deepsleep mako-iot ESP32</tags>
     <dependencies>
-      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.56.42770" />
+      <dependency id="MakoIoT.Device.Services.Interface" version="1.0.57.48509" />
       <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
       <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
       <dependency id="nanoFramework.Hardware.Esp32" version="1.6.34" />

--- a/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders.nfproj
+++ b/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders.nfproj
@@ -26,7 +26,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="MakoIoT.Device.Services.Interface, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.56.42770\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
+      <HintPath>..\..\packages\MakoIoT.Device.Services.Interface.1.0.57.48509\lib\MakoIoT.Device.Services.Interface.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>

--- a/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/packages.config
+++ b/src/MakoIoT.Device.Services.ESP32.DeepSleepDataProviders/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MakoIoT.Device.Services.Interface" version="1.0.56.42770" targetFramework="netnano1.0" />
+  <package id="MakoIoT.Device.Services.Interface" version="1.0.57.48509" targetFramework="netnano1.0" />
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Hardware.Esp32" version="1.6.34" targetFramework="netnano1.0" />


### PR DESCRIPTION
Bumps MakoIoT.Device.Services.Interface from 1.0.56.42770 to 1.0.57.48509</br>
[version update]

### :warning: This is an automated update. :warning:
